### PR TITLE
Allow to work with custom manager classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Installation
 There's nothing required apart from a simple
 
 	pip install django-scopes
-	
+
 Compatibility
 -------------
 
@@ -96,6 +96,8 @@ Now, with this custom manager, all queries are banned at first:
 The only thing that will work is ``Comment.objects.none()``, which is useful e.g. for Django
 generic view definitions.
 
+### Activate scopes in contexts
+
 You can now use our context manager to specifically allow queries to a specific blogging site,
 e.g.:
 
@@ -147,6 +149,26 @@ def fun(…):
     …
 ```
 
+### Custom manager classes
+
+If you were already using a custom manager class, you can pass it to a `ScopedManager` with the `_manager_class`
+keyword like this:
+from django.db import models
+
+```python
+from django.db import models
+
+class SiteManager(models.Manager):
+
+	def get_queryset(self):
+		return super().get_queryset().exclude(name__startswith='test')
+
+class Site(models.Model):
+	name = models.CharField(…)
+
+	objects = ScopedManager(site='site', _manager_class=SiteManager)
+```
+
 Caveats
 -------
 
@@ -157,7 +179,7 @@ a better solution than to monkeypatch it:
 ```python
 from django.test import utils
 from django_scopes import scopes_disabled
-    
+
 utils.setup_databases = scopes_disabled()(utils.setup_databases)
 ```
 

--- a/django_scopes/manager.py
+++ b/django_scopes/manager.py
@@ -64,10 +64,10 @@ class DisabledQuerySet(models.QuerySet):
     values_list = error
 
 
-def ScopedManager(**scopes):
+def ScopedManager(_manager_class=models.Manager, **scopes):
     required_scopes = set(scopes.keys())
 
-    class Manager(models.Manager):
+    class Manager(_manager_class):
         def __init__(self):
             super().__init__()
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -28,6 +28,11 @@ def post2(site2):
 
 
 @pytest.fixture
+def deleted_post(site1):
+    return Post.objects.create(site=site1, title="deleted")
+
+
+@pytest.fixture
 def comment1(post1):
     return Comment.objects.create(post=post1, text="I'm so sorry.")
 
@@ -144,6 +149,12 @@ def test_scope_multisite(site1, site2, comment1, comment2):
     with scope(site=[site1, site2]):
         assert list(Comment.objects.all()) == [comment1, comment2]
         assert get_scope() == {'site': [site1, site2], '_enabled': True}
+
+
+@pytest.mark.django_db
+def test_scope_uses_manager_class(site1, post1, deleted_post):
+    with scope(site=site1):
+        assert deleted_post not in site1.post_set.all()
 
 
 @pytest.mark.django_db

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -2,6 +2,12 @@ from django.db import models
 from django_scopes import ScopedManager
 
 
+class PostManager(models.Manager):
+
+    def get_queryset(self):
+        return super().get_queryset().exclude(title='deleted')
+
+
 class Site(models.Model):
     name = models.CharField(max_length=200)
 
@@ -13,7 +19,7 @@ class Post(models.Model):
     site = models.ForeignKey(Site, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
 
-    objects = ScopedManager(site='site')
+    objects = ScopedManager(site='site', _manager_class=PostManager)
 
 
 class Comment(models.Model):


### PR DESCRIPTION
Sometimes you are already doing queryset modifications on your models (think: excluding soft-deleted rows), but you still want to profit from scoping. This PR introduces the `_manager_class` named argument for the `ScopeManager`.