### PR TITLE
Remove the dot from the pytest command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     -Urrequirements_dev.txt
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-commands = py.test tests
+commands = pytest tests
 
 [testenv:coverage]
 basepython=python3.7
@@ -20,7 +20,7 @@ deps=
     django==2.2.*
 commands =
     coverage erase
-    coverage run -m py.test tests
+    coverage run -m pytest tests
     coverage report
     codecov -e TOXENV
 


### PR DESCRIPTION
Remove the dot from the pytest command
As recomended since [3.0.0](https://docs.pytest.org/en/latest/changelog.html#id1110) version