### PR TITLE
Replace threading.local with contextvars.ContextVar

### DIFF
--- a/django_scopes/state.py
+++ b/django_scopes/state.py
@@ -1,7 +1,8 @@
 from contextlib import contextmanager
-from threading import local
+from contextvars import ContextVar
+from typing import Optional
 
-state = local()
+state: ContextVar[Optional[dict]] = ContextVar('state', default=None)
 
 
 @contextmanager
@@ -12,19 +13,20 @@ def scopes_disabled():
 
 @contextmanager
 def scope(**scope_kwargs):
-    if not hasattr(state, 'scope'):
-        state.scope = {}
+    previous_scope = state.get()
+    if previous_scope is None:
+        previous_scope = {}
+        state.set(previous_scope)
 
-    previous_scope = getattr(state, 'scope', {})
     new_scope = dict(previous_scope)
     new_scope['_enabled'] = True
     new_scope.update(scope_kwargs)
-    state.scope = new_scope
+    state.set(new_scope)
     try:
         yield
     finally:
-        state.scope = previous_scope
+        state.set(previous_scope)
 
 
 def get_scope():
-    return dict(getattr(state, 'scope', {}))
+    return state.get() or {}


### PR DESCRIPTION
This allows usage of scopes with async code.

Per https://docs.python.org/3/library/contextvars.html

> Context managers that have state should use Context Variables instead of [threading.local()](https://docs.python.org/3/library/threading.html#threading.local) to prevent their state from bleeding to other code unexpectedly, when used in concurrent code.

Only the internal `state` variable in `django_scopes/state.py` is changed. This should have no outside visible effect except from now being compatible with both threaded and async code.