### PR TITLE
Allow to modify scoping for a single query

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ Please note that **django-scopes** is also active during migrations, so if you a
 data migration – or have written one in the past! – you'll have to add appropriate scoping
 or use the ``scopes_disabled`` context.
 
+You can modify the scope for a single query:
+
+```python
+with scope(site=[site1]):
+	Comment.objects.all()  # scoped to site1
+    Comment.objects.with_scope(site=site2).all()  # scoped to site 2
+    Comment.objects.with_scopes_disabled().all()  # unscoped
+```
+
 ### Custom manager classes
 
 If you were already using a custom manager class, you can pass it to a `ScopedManager` with the `_manager_class`

--- a/django_scopes/manager.py
+++ b/django_scopes/manager.py
@@ -1,3 +1,5 @@
+import copy
+
 from django.db import models
 
 from .exceptions import ScopeError
@@ -71,8 +73,22 @@ def ScopedManager(_manager_class=models.Manager, **scopes):
         def __init__(self):
             super().__init__()
 
+        def with_scope(self, **scope):
+            cloned = copy.copy(self)
+            scope['_enabled'] = True
+            cloned._override_scope = scope
+            return cloned
+
+        def with_scopes_disabled(self):
+            cloned = copy.copy(self)
+            cloned._override_scope = {'_enabled': False}
+            return cloned
+
         def get_queryset(self):
-            current_scope = get_scope()
+            if hasattr(self, '_override_scope'):
+                current_scope = self._override_scope
+            else:
+                current_scope = get_scope()
             if not current_scope.get('_enabled', True):
                 return super().get_queryset()
             missing_scopes = required_scopes - set(current_scope.keys())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 160
 exclude = migrations,.ropeproject,settings.py,conftest.py
-max-complexity = 11
+max-complexity = 13
 
 [isort]
 combine_as_imports = true

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -256,3 +256,12 @@ def test_forms_require_scope(comment1, commentgroup):
     with pytest.raises(ScopeError):
         assert CommentForm(instance=comment1)
         assert CommentGroupForm(instance=commentgroup)
+
+
+@pytest.mark.django_db
+def test_override_scope_on_manager(site1, site2, post1, post2):
+    with scope(site=site1):
+        assert list(Post.objects.all()) == [post1]
+        assert list(Post.objects.with_scope(site=site2).all()) == [post2]
+        assert list(Post.objects.with_scope(site=None).all()) == [post1, post2]
+        assert list(Post.objects.with_scopes_disabled().all()) == [post1, post2]


### PR DESCRIPTION
django-scopes provides a failsafe by adding filter() statements to every query. However, in some situations they can be harmful. For example, django-scopes might turn

    Page.objects.filter(Exists(Comment.objects.filter(page=OuterRef("pk"))))

into

    Page.objects.filter(site=scoped_site, Exists(Comment.objects.filter(page=OuterRef("pk"), page__site=scoped_site)))

In the second example, the `page__site` in the subquery is completely pointless but might cause the database to do additional JOINs or make use suboptimal use of an index.

Therefore, I propose we make a better way to opt-out for single subqueries.